### PR TITLE
Fix Error: Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "firebase-config-json" does not.  

### DIFF
--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -69,7 +69,7 @@ function SettingsPage() {
     try {
       setLoading(true);
       const data = await saveFirebaseConfig(firebaseJsonValueInput);
-      setFirebaseJsonValue(data["firebase-config-json"]);
+      setFirebaseJsonValue(data["firebase_config_json"]);
       setLoading(false);
       toggleNotification({
         type: "success",

--- a/server/content-types/firebase-auth-configuration/schema.json
+++ b/server/content-types/firebase-auth-configuration/schema.json
@@ -18,7 +18,7 @@
     }
   },
   "attributes": {
-    "firebase-config-json": {
+    "firebase_config_json": {
       "type": "json"
     }
   }

--- a/server/services/settingsService.ts
+++ b/server/services/settingsService.ts
@@ -22,7 +22,7 @@ export default ({ strapi }) => {
           }
           return;
         }
-        const jsonObject = res["firebase-config-json"];
+        const jsonObject = res["firebase_config_json"];
         if (!jsonObject || !jsonObject.firebaseConfigJson) {
           if (strapi.firebase) {
             await strapi.firebase.delete();
@@ -50,7 +50,7 @@ export default ({ strapi }) => {
         const configObject = await strapi.entityService.findMany(
           "plugin::firebase-auth.firebase-auth-configuration",
         );
-        const firebaseConfigJsonObj = configObject["firebase-config-json"];
+        const firebaseConfigJsonObj = configObject["firebase_config_json"];
         const hashedJson = firebaseConfigJsonObj["firebaseConfigJson"];
 
         const firebaseConfigJson = await this.decryptJson(key, hashedJson);
@@ -82,7 +82,7 @@ export default ({ strapi }) => {
           res = await strapi.entityService.create(
             "plugin::firebase-auth.firebase-auth-configuration",
             {
-              data: { "firebase-config-json": { firebaseConfigJson: hash } },
+              data: { "firebase_config_json": { firebaseConfigJson: hash } },
             },
           );
         } else {
@@ -91,19 +91,19 @@ export default ({ strapi }) => {
             isExist.id,
             {
               data: {
-                "firebase-config-json": { firebaseConfigJson: hash },
+                "firebase_config_json": { firebaseConfigJson: hash },
               },
             },
           );
         }
         await strapi.plugin("firebase-auth").service("settingsService").init();
         const firebaseConfigHash =
-          res["firebase-config-json"].firebaseConfigJson;
+          res["firebase_config_json"].firebaseConfigJson;
         const firebaseConfigJsonValue = await this.decryptJson(
           encryptionKey,
           firebaseConfigHash,
         );
-        res["firebase-config-json"].firebaseConfigJson =
+        res["firebase_config_json"].firebaseConfigJson =
           firebaseConfigJsonValue;
         return res;
       } catch (error) {


### PR DESCRIPTION
I was having the issue regarding variable name, and lookup about strapi that's integrated using graphql doesn't support '-' special character. If you don't mind changing the variable naming, to something like "firebase_config_json" or anything that doesn't contain '-', it will solve the graphql naming issue.

![image](https://github.com/swensonhe/strapi-firebase-auth/assets/31056582/fa5cfe54-bbbe-40f1-a272-1423a89dcaf0)

